### PR TITLE
fix: Correct mismatched closing tag for logo link in Header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -50,7 +50,7 @@ const Header = () => {
               alt="Claryon Group Logo"
               className="h-12 w-auto"
             />
-          </Link>
+          </a>
 
           <nav className="hidden lg:flex items-center space-x-8">
             {navItems.map((item: any) => (


### PR DESCRIPTION
The previous commit introduced a build error due to an incorrect closing tag for the CLARYON logo link in `src/components/Header.tsx`. The link was changed from a React Router `Link` to an `<a>` tag to support `target="_blank"`, but the closing tag was not updated.

This commit changes the closing `</Link>` tag to `</a>` to match the opening `<a>` tag, resolving the build failure.