### PR TITLE
fix: Update logo URL for improved visibility

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
         <div className="flex justify-between items-center h-20">
           <a href="https://drive.google.com/file/d/1OE6kDWnhzA4005eBc7F8e6YrbGtnxIOD/view?usp=drive_link" target="_blank" rel="noopener noreferrer" className="flex items-center space-x-3" onClick={() => setIsOpen(false)}>
             <img 
-              src="/new_logo.png"
+              src="https://drive.google.com/uc?export=view&id=1LVM6RX8Aubk0iFiutUUi_vZSblI8A8oX"
               alt="Claryon Group Logo"
               className="h-12 w-auto"
             />
@@ -118,7 +118,7 @@ const Header = () => {
               <div className="flex flex-col space-y-6 mt-2">
                 <Link to="/" className="mb-4" onClick={() => setIsOpen(false)}>
                   <img
-                    src="/new_logo.png"
+                    src="https://drive.google.com/uc?export=view&id=1LVM6RX8Aubk0iFiutUUi_vZSblI8A8oX"
                     alt="Claryon Group Logo"
                     className="h-10 w-auto"
                   />


### PR DESCRIPTION
The website logo was reportedly not visible. This commit updates the logo's `src` attribute in `src/components/Header.tsx` to a new, direct PNG image URL hosted on Google Drive.

The new URL (`https://drive.google.com/uc?export=view&id=1LVM6RX8Aubk0iFiutUUi_vZSblI8A8oX`) is applied to both the desktop and mobile versions of the logo to ensure it renders correctly.