### PR TITLE
fix: Update logo URL to Cloudinary for visibility

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
         <div className="flex justify-between items-center h-20">
           <a href="https://drive.google.com/file/d/1OE6kDWnhzA4005eBc7F8e6YrbGtnxIOD/view?usp=drive_link" target="_blank" rel="noopener noreferrer" className="flex items-center space-x-3" onClick={() => setIsOpen(false)}>
             <img 
-              src="https://drive.google.com/uc?export=view&id=1LVM6RX8Aubk0iFiutUUi_vZSblI8A8oX"
+              src="https://asset.cloudinary.com/dq03afeam/571363048079157f8a5c33b7434a1fae"
               alt="Claryon Group Logo"
               className="h-12 w-auto"
             />
@@ -118,7 +118,7 @@ const Header = () => {
               <div className="flex flex-col space-y-6 mt-2">
                 <Link to="/" className="mb-4" onClick={() => setIsOpen(false)}>
                   <img
-                    src="https://drive.google.com/uc?export=view&id=1LVM6RX8Aubk0iFiutUUi_vZSblI8A8oX"
+                    src="https://asset.cloudinary.com/dq03afeam/571363048079157f8a5c33b7434a1fae"
                     alt="Claryon Group Logo"
                     className="h-10 w-auto"
                   />


### PR DESCRIPTION
The previously attempted Google Drive URLs for the logo did not render correctly. This commit updates the logo's `src` attribute in `src/components/Header.tsx` to a new image URL hosted on Cloudinary, as provided by you.

The new URL (`https://asset.cloudinary.com/dq03afeam/571363048079157f8a5c33b7434a1fae`) is applied to both the desktop and mobile versions of the logo to ensure it renders correctly and is visible.